### PR TITLE
Fix matching delimiter across buffer boundaries

### DIFF
--- a/src/readers/delimiter_reader.rs
+++ b/src/readers/delimiter_reader.rs
@@ -84,9 +84,14 @@ impl<R: AsyncRead + Unpin> AsyncRead for AsyncDelimiterReader <R> {
                 self.inner.prepend(actual_read_slice);
                 b.set_filled(match_index);
             } else if !full_match {
-                let pp = &read_slice[match_index..];
-                self.inner.prepend(pp);
+                let partial_delimiter = &read_slice[match_index..];
+                self.inner.prepend(partial_delimiter);
                 b.set_filled(match_index);
+
+                if match_index == 0 {
+                    c.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
             }
 
             if full_match {

--- a/src/readers/delimiter_reader.rs
+++ b/src/readers/delimiter_reader.rs
@@ -83,6 +83,10 @@ impl<R: AsyncRead + Unpin> AsyncRead for AsyncDelimiterReader <R> {
                 let actual_read_slice = &read_slice[index..];
                 self.inner.prepend(actual_read_slice);
                 b.set_filled(match_index);
+            } else if !full_match {
+                let pp = &read_slice[match_index..];
+                self.inner.prepend(pp);
+                b.set_filled(match_index);
             }
 
             if full_match {

--- a/src/readers/prepend_reader.rs
+++ b/src/readers/prepend_reader.rs
@@ -59,8 +59,12 @@ impl<R: AsyncRead + Unpin> AsyncRead for AsyncPrependReader<R> {
         if let Poll::Ready(Err(_)) = &poll {
             return poll;
         } 
-
-        poll
+        
+        if buffer_filled {
+            Poll::Ready(Ok(()))
+        } else {
+            poll
+        }
     }
 }
 

--- a/src/readers/prepend_reader.rs
+++ b/src/readers/prepend_reader.rs
@@ -59,12 +59,8 @@ impl<R: AsyncRead + Unpin> AsyncRead for AsyncPrependReader<R> {
         if let Poll::Ready(Err(_)) = &poll {
             return poll;
         } 
-        
-        if buffer_filled {
-            Poll::Ready(Ok(()))
-        } else {
-            poll
-        }
+
+        poll
     }
 }
 


### PR DESCRIPTION
This fixes Majored/rs-async-zip#27 and Majored/rs-async-zip#22.

#### About Majored/rs-async-zip#22 in specific

Although the [issue](https://github.com/Majored/rs-async-zip/issues/22) is about reading zip(s) inside zip, the problem is not really with inner-zipping (idk if there is a correct compound word for this), it is totally related to buffer boundary and delimiter match.

#### Changes
I've tried two approaches, one was using a State Machine to track matching process, but I didn't liked how it added too much complexity, so I went with a simpler approach: 

On partial matches, we *prepend* partial matched bytes to the inner reader. And on the **AsyncPrependReader**, instead of immediately returning the filled buffer, we just return the result of `poll`. This may add some latency for reading process in some places, although I don't think it would really do (because the delimiter size is too tiny). But that will ensure that we have the needed amount of bytes to try to match the delimiter.

**Safety**

This is safe because, if `poll` ever return `Ready(Ok(_))` without really filling the *buf* (which is a sign of EOF), the `buf.filled().len()` will not be equals the value of before calling `AsyncPrependReader::poll` since the value is already prepended to the buffer.

The only problem is, if `poll` fails with `Ready(Err(_))`, the bytes to prepend, that was already available, will be lost.

#### Tests

I've tested [Majored/rs-async-zip](https://github.com/Majored/rs-async-zip) with those patches, and all the zip files provided in:

- [this comment](https://github.com/Majored/rs-async-zip/issues/22#issuecomment-1172798741), both of them
- [this one](https://github.com/Majored/rs-async-zip/pull/27#issue-1293334718)
- [and this one](https://github.com/Majored/rs-async-zip/pull/27#issuecomment-1174014609)

All of them passes.